### PR TITLE
Correct typo in docstring of responder

### DIFF
--- a/src-cljs/clj-pouchdb/core.cljs
+++ b/src-cljs/clj-pouchdb/core.cljs
@@ -66,7 +66,7 @@
   (obj-to-hash jso))
 
 (defn- responder
-  "Create am [err resp] callback putting a proper structure to the given channel"
+  "Create an [err resp] callback putting a proper structure to the given channel"
   [c]
   (fn [err resp]
     (let [obj (or (create-error err) (create-result resp))]


### PR DESCRIPTION
Just a 1 char change. Thanks for sharing this library, by the way.